### PR TITLE
fix parsing to not misinterpret words starting with logical operators

### DIFF
--- a/plasticparser/tokenizer.py
+++ b/plasticparser/tokenizer.py
@@ -3,7 +3,7 @@
 from peak.util.proxies import LazyProxy
 from pyparsing import (
     Word, QuotedString, oneOf, CaselessLiteral, White,
-    OneOrMore, Optional, alphanums, srange, ZeroOrMore)
+    OneOrMore, Optional, alphanums, srange, ZeroOrMore, CaselessKeyword)
 from .grammar_parsers import (
     parse_logical_expression, parse_compare_expression, parse_free_text,
     parse_paren_base_logical_expression, join_brackets, join_words,
@@ -37,7 +37,7 @@ def get_operator():
 
 
 def get_logical_operator():
-    return CaselessLiteral('AND') | CaselessLiteral('OR') | White().suppress()
+    return CaselessKeyword('AND') | CaselessKeyword('OR') | White().suppress()
 
 
 def get_logical_expression():

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = """
  """
 
 setup(name='plasticparser',
-      version='0.2.9.3',
+      version='0.2.9.4',
       description='An Elastic Search Query Parser',
       long_description=long_description,
       url='https://github.com/Aplopio/plasticparser',

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -91,6 +91,41 @@ class TokenizerTest(unittest.TestCase):
 
         self.assertEqual(parsed_string, expected_query_string)
 
+    def test_should_not_misinterpret_words_starting_with_logical_ops(self):
+        query_string = "type:candidates AND nested:[metadata_facets(field_name:(location) AND field_value:(orlando))] "
+        parsed_string = tokenizer.tokenize(query_string)
+        expected_query_string = {
+            'query': {
+                'filtered': {
+                    'filter': {
+                        'bool': {
+                            'should': [],
+                            'must_not': [],
+                            'must': [
+                                {
+                                    'type': {
+                                        'value': u'candidates'
+                                    }
+                                },
+                                {
+                                    'nested': {
+                                        'path': u'metadata_facets',
+                                        'query': {
+                                            'query_string': {
+                                                'query': u'field_name:(location) AND field_value:(orlando)',
+                                                'default_operator': 'and'
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(parsed_string, expected_query_string)
+
     def test_should_parse_logical_expression_with_type(self):
         query_string = "type:def (abc:>def mms:>asd)"
         parsed_string = tokenizer.tokenize(query_string)


### PR DESCRIPTION
Issue: Facet query search of words like `orlando` were interpreted as `OR lando`.
The fix makes sure the logical operators (`AND`, `OR`) are `caseless keywords`, i.e they are individual words, not part of a different word.