### PR TITLE
Add support for aggregations

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+test:
+  override:
+    - ./run_tests.sh
+
+dependencies:
+  override:
+    - pip install -r dev-requirements.txt

--- a/plasticparser/grammar_parsers.py
+++ b/plasticparser/grammar_parsers.py
@@ -160,6 +160,9 @@ def parse_type_logical_facets_expression(tokens):
         query_dsl['facets'] = facets
     if aggs:
         query_dsl['aggregations'] = aggs
+        # `size` is added in version 2.0
+        # `size` is used to return only counts without hits
+        query_dsl['size'] = 0
     if query:
         query_dsl["query"]["filtered"]["query"] = {
             "query_string": {

--- a/plasticparser/grammar_parsers.py
+++ b/plasticparser/grammar_parsers.py
@@ -15,6 +15,14 @@ class Facets(object):
         return self.facets_dsl
 
 
+class Aggregations(object):
+    def __init__(self, facets_dsl):
+        self.facets_dsl = facets_dsl
+
+    def get_query(self):
+        return self.facets_dsl
+
+
 class Nested(object):
     def __init__(self, nested_dsl):
         self.nested_dsl = nested_dsl
@@ -96,6 +104,9 @@ def default_parse_func(tokens):
         if isinstance(token, Facets):
             return_list.append(token)
             token_list.remove(token)
+        if isinstance(token, Aggregations):
+            return_list.append(token)
+            token_list.remove(token)
         if isinstance(token, type):
             return_list.append(token)
             token_list.remove(token)
@@ -118,6 +129,7 @@ def parse_type_logical_facets_expression(tokens):
     should_list = []
     must_not_list = []
     facets = {}
+    aggs = {}
     for token in tokens.asList():
         if isinstance(token, Nested):
             nested = token.get_query()
@@ -126,6 +138,8 @@ def parse_type_logical_facets_expression(tokens):
             query = token.get_query()
         if isinstance(token, Facets):
             facets = token.get_query()
+        if isinstance(token, Aggregations):
+            aggs = token.get_query()
         if isinstance(token, Type):
             type = token.get_query()
             must_list.append(type)
@@ -144,6 +158,8 @@ def parse_type_logical_facets_expression(tokens):
     }
     if facets:
         query_dsl['facets'] = facets
+    if aggs:
+        query_dsl['aggregations'] = aggs
     if query:
         query_dsl["query"]["filtered"]["query"] = {
             "query_string": {
@@ -180,11 +196,54 @@ def parse_single_facet_expression(tokens):
     return filters
 
 
+def parse_single_aggs_expression(tokens):
+    aggs_key = tokens[0]
+    filters = {
+        aggs_key: {
+            "aggregations": {
+                aggs_key: {}
+            }
+        }
+    }
+    field = aggs_key
+    if "." in aggs_key:
+        nested_keys = aggs_key.split(".")
+        nested_field = u".".join(nested_keys[:-1])
+
+    field = "{}_nonngram".format(field)
+    filters[aggs_key]["aggregations"][aggs_key]["terms"] = {
+        "field": field, "size": getattr(
+            plasticparser, 'FACETS_QUERY_SIZE', 20)
+    }
+
+    if len(tokens) > 1:
+        filters[aggs_key]["aggregations"][aggs_key]["aggregations"] = {
+            aggs_key: {'filter': {
+                "query": {
+                    "query_string": {
+                        "query": tokens[1], "default_operator": "and"
+                    }
+                }
+            }}
+        }
+
+    if len(tokens) > 1 and "." in aggs_key:
+        filters[aggs_key]['nested'] = {'path': nested_field}
+    return filters
+
+
 def parse_base_facets_expression(tokens):
     facets = {}
     for tok in tokens.asList():
         facets.update(tok)
     return Facets(facets)
+
+
+def parse_base_aggs_expression(tokens):
+    aggs = {}
+    for tok in tokens.asList():
+        aggs.update(tok)
+    return Aggregations(aggs)
 
 
 def join_words(tokens):
@@ -196,6 +255,10 @@ def join_brackets(tokens):
 
 
 def parse_one_or_more_facets_expression(tokens):
+    return u' '.join(tokens)
+
+
+def parse_one_or_more_aggs_expression(tokens):
     return u' '.join(tokens)
 
 

--- a/plasticparser/grammar_parsers.py
+++ b/plasticparser/grammar_parsers.py
@@ -197,6 +197,30 @@ def parse_single_facet_expression(tokens):
 
 
 def parse_single_aggs_expression(tokens):
+    """
+    Parses single aggregation query. Following is example input and output:
+
+    INPUT
+    type:candidates (name:"John Doe" starred:true) (python or java) facets:[location]
+
+    OUTPUT
+    {
+        ...
+        "aggregations": {
+            "location": {
+                "aggregations": {
+                    "location": {
+                        "terms": {
+                            "field": "location_nonngram",
+                            "size": 20
+                        }
+                    }
+                }
+            }
+        }
+        ...
+    }
+    """
     aggs_key = tokens[0]
     filters = {
         aggs_key: {

--- a/plasticparser/grammar_parsers.py
+++ b/plasticparser/grammar_parsers.py
@@ -16,11 +16,11 @@ class Facets(object):
 
 
 class Aggregations(object):
-    def __init__(self, facets_dsl):
-        self.facets_dsl = facets_dsl
+    def __init__(self, aggregations_dsl):
+        self.aggregations_dsl = aggregations_dsl
 
     def get_query(self):
-        return self.facets_dsl
+        return self.aggregations_dsl
 
 
 class Nested(object):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = """
  """
 
 setup(name='plasticparser',
-      version='0.2.9.4',
+      version='0.3.0',
       description='An Elastic Search Query Parser',
       long_description=long_description,
       url='https://github.com/Aplopio/plasticparser',

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -117,6 +117,7 @@ class TokenizerTest(unittest.TestCase):
                     }
                 }
             },
+            "size": 0,
             'aggregations': {
                 'aaa': {
                     'aggregations': {
@@ -256,6 +257,7 @@ class TokenizerTest(unittest.TestCase):
                     }
                 }
             },
+            "size": 0,
             "aggregations": {
                 "aaa.bb": {
                     "aggregations": {
@@ -336,16 +338,49 @@ class TokenizerTest(unittest.TestCase):
                              'query': {'query_string': {'query': u'(abc:>def mms:>asd)', 'default_operator': 'and'}}}},
                             'facets': {'aaa.bb': {'terms': {'field': 'aaa.bb_nonngram', 'size': 20}}}})
 
-    def test_should_parse_basic_logical_expression_aggs_with_no_facet_filters(
+    def test_should_parse_basic_logical_expression_aggs_with_no_filters(
             self):
         query_string = "type:def (abc:>def mms:>asd) aggregations: [ aaa.bb ]"
         parsed_string = tokenizer.tokenize(query_string)
         self.assertEqual(
             parsed_string, {
                 'query': {
-                    'filtered': {'filter': {'bool': {'should': [], 'must_not': [], 'must': [{'type': {'value': 'def'}}]}},
-                             'query': {'query_string': {'query': u'(abc:>def mms:>asd)', 'default_operator': 'and'}}}},
-                            'aggregations': {'aaa.bb': {'aggregations': {'aaa.bb': {'terms': {'field': 'aaa.bb_nonngram', 'size': 20}}}}}})
+                    'filtered': {
+                        'filter': {
+                            'bool': {
+                                'should': [],
+                                'must_not': [],
+                                'must': [
+                                    {
+                                        'type': {
+                                            'value': 'def'
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        'query': {
+                            'query_string': {
+                                'query': u'(abc:>def mms:>asd)',
+                                'default_operator': 'and'
+                            }
+                        }
+                    }
+                },
+                "size": 0,
+                'aggregations': {
+                    'aaa.bb': {
+                        'aggregations': {
+                            'aaa.bb': {
+                                'terms': {
+                                    'field': 'aaa.bb_nonngram', 'size': 20
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
 
     def test_should_parse_basic_logical_expression_facets_with_simple_field(
             self):


### PR DESCRIPTION
### Description
Elasticsearch has deprecated facets and aggregrations are to be used hence forth. These changes will add support for aggregations and will keep facets as well. Facets will be deprecated in coming versions.

Aggregations Reference:
https://www.elastic.co/guide/en/elasticsearch/reference/1.5/search-aggregations.html

Facets Deprecation:
https://www.elastic.co/guide/en/elasticsearch/reference/1.5/search-facets.html

### Query Changes
There are no major changes in query, to make aggregations query `facets` needs to replaced by `aggregations` eg:

Old facets query
```
type:candidates (name:"John Doe" starred:true) (python or java) facets:[location]
```

New aggregations query
```
type:candidates (name:"John Doe" starred:true) (python or java) aggregations:[location]
```

Generated Query:
```json
{
    "sort": [
        {
            "created_on": "desc"
        }
    ],
    "query": {
        "filtered": {
            "filter": {
                "bool": {
                    "should": [],
                    "must_not": [],
                    "must": [
                        {
                            "type": {
                                "value": "candidates"
                            }
                        },
                        {
                            "term": {
                                "client_id": 1
                            }
                        },
                        {
                            "term": {
                                "user_id": 2
                            }
                        }
                    ]
                }
            },
            "query": {
                "query_string": {
                    "query": "(name:\"John Doe\" starred:true) (python OR java)",
                    "default_operator": "and"
                }
            }
        }
    },
    "aggregations": {
        "location": {
            "aggregations": {
                "location": {
                    "terms": {
                        "field": "location_nonngram",
                        "size": 20
                    }
                }
            }
        }
    }
}
```