### PR TITLE
Add support for highlighting fields

### DIFF
--- a/tests/test_plasticparser.py
+++ b/tests/test_plasticparser.py
@@ -59,6 +59,41 @@ class PlasticParserTestCase(unittest.TestCase):
         elastic_query_dsl = plasticparser.get_query_dsl(query_string)
         self.assertEqual(elastic_query_dsl, expected_query_dsl)
 
+    def test_should_return_elastic_search_query_dsl_for_queries_with_highlight_fields(self):
+        query_string = 'highlight:[field,due_date] type:help and field:"asdsad" (due_date:>=1234)'
+        expected_query_dsl = {
+            'query': {
+                'filtered': {
+                    'filter': {
+                        'bool': {
+                            'should': [],
+                            'must_not': [],
+                            'must': [
+                                {
+                                    'type': {
+                                        'value': u'help'
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    'query': {
+                        'query_string': {
+                            'query': u'field:"asdsad" (due_date:>=1234)',
+                            'default_operator': 'and'
+                        }
+                    }
+                }
+            },
+            'highlight': {
+                'fields': {
+                    'field': {},
+                    'due_date': {}
+                }
+            }
+        }
+        elastic_query_dsl = plasticparser.get_query_dsl(query_string)
+        self.assertEqual(elastic_query_dsl, expected_query_dsl)
 
     def test_should_return_elastic_search_query_dsl_for_basic_query_with_type(self):
         query_string = 'type:help and title:hello description:"world"'

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -436,3 +436,31 @@ class TokenizerTest(unittest.TestCase):
         parsed_string = tokenizer.tokenize(query_string)
         self.assertEqual(parsed_string['query']['filtered']['query']['query_string']['query'],
                          u'tags:dev\:ops')
+
+    def test_should_add_highlight_fields(self):
+        query_string = "highlight:[aaa] asdasd"
+        parsed_string = tokenizer.tokenize(query_string)
+        self.assertEqual(parsed_string, {
+            'query': {
+                'filtered': {
+                    'filter': {
+                        'bool': {
+                            'should': [],
+                            'must_not': [],
+                            'must': []
+                        }
+                    },
+                    'query': {
+                        'query_string': {
+                            'query': u'asdasd',
+                            'default_operator': 'and'
+                        }
+                    }
+                }
+            },
+            'highlight': {
+                'fields': {
+                    u'aaa': {}
+                }
+            }
+        })


### PR DESCRIPTION
### Description
Elasticsearch has feature for highlighting matched terms from the search query in the results. These changes will add support for specifying fields in which search term will be highlighted.

### Example
Query:
`highlight:[fieldname] search string"`
for all fields:
`highlight:[_all] search string"`

Generated elasticsearch query:

```json
{
  "query": {
    "filtered": {
      "filter": {
        "bool": {
          "should": [],
          "must_not": [],
          "must": []
        }
      },
      "query": {
        "query_string": {
          "query": "search string",
          "default_operator": "and"
        }
      }
    }
  },
  "highlight": {
    "fields": {
      "fieldname": {}
    }
  }
}
```

### TODO
Support more options provided by Elasticsearch on fields.